### PR TITLE
Modifications that take into account OOD updates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,13 +28,7 @@ class openondemand::config {
   }
 
   #Yaml_setting <| tag == 'nginx_stage' |> {
-  #  target => 
-  #}
-
-  #yaml_setting { 'nginx_stage-opt_in_metrics':
-  #  target => '/opt/ood/nginx_stage/config/nginx_stage.yml',
-  #  key    => 'opt_in_metrics',
-  #  value  => $openondemand::nginx_stage_opt_in_metrics,
+  #  target =>
   #}
 
   #yaml_setting { 'nginx_stage-app_root':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,14 @@ class openondemand::config {
     content => template('openondemand/nginx_stage.yml.erb'),
   }
 
+  file { '/opt/ood/nginx_stage/bin/ood_ruby':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    content => template('openondemand/ood_ruby.erb'),
+  }
+
   file { $openondemand::ood_public_root:
     ensure => $openondemand::_public_ensure,
     target => $openondemand::_public_target,
@@ -86,18 +94,4 @@ class openondemand::config {
     mode    => '0644',
     content => template('openondemand/ood-cron.erb'),
   }
-
-  exec { 'nginx_stage enable scl':
-    path    => '/usr/bin:/bin:/usr/sbin:/sbin',
-    command => "sed -i 's/^#exec scl/exec scl/g' /opt/ood/nginx_stage/bin/ood_ruby",
-    unless  => "egrep -q '^exec scl' /opt/ood/nginx_stage/bin/ood_ruby",
-  }
-
-  file_line { 'ood_ruby-scl':
-    path    => '/opt/ood/nginx_stage/bin/ood_ruby',
-    line    => "exec scl enable ${openondemand::nginx_stage_ood_ruby_scl} -- exec /bin/env ruby \"\$@\"",
-    match   => '^exec scl',
-    require => Exec['nginx_stage enable scl'],
-  }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class openondemand (
   $ood_server_aliases               = [],
   $ood_logs                         = true,
   $ood_public_root                  = '/var/www/ood/public',
+  $ood_host_regex                   = '[^/]+',
   $ood_public_uri                   = '/public',
   $ood_user_map_cmd                 = '/opt/ood/ood_auth_map/bin/ood_auth_map',
   $ood_pun_stage_cmd                = '/opt/ood/nginx_stage/sbin/nginx_stage',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,6 @@ class openondemand (
   $ood_analytics_tracking_url       = 'http://www.google-analytics.com/collect',
   $ood_analytics_tracking_id        = 'UA-79331310-4',
 
-  $nginx_stage_opt_in_metrics       = false,
   $nginx_stage_app_root             = $openondemand::params::nginx_stage_app_root,
   $nginx_stage_ood_ruby_scl         = 'nginx16 rh-passenger40 rh-ruby22 nodejs010 git19',
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,8 +10,7 @@ class openondemand::service {
     subscribe   => [
       Openondemand::Install::Component['nginx_stage'],
       File['/opt/ood/nginx_stage/config/nginx_stage.yml'],
-      Exec['nginx_stage enable scl'],
-      File_line['ood_ruby-scl'],
+      File['/opt/ood/nginx_stage/bin/ood_ruby'],
     ],
   }->
   exec { 'nginx_stage-app_reset-pun':
@@ -20,8 +19,7 @@ class openondemand::service {
     subscribe   => [
       Openondemand::Install::Component['nginx_stage'],
       File['/opt/ood/nginx_stage/config/nginx_stage.yml'],
-      Exec['nginx_stage enable scl'],
-      File_line['ood_ruby-scl'],
+      File['/opt/ood/nginx_stage/bin/ood_ruby'],
     ],
   }->
   exec { 'nginx_stage-nginx_clean':
@@ -30,8 +28,7 @@ class openondemand::service {
     subscribe   => [
       Openondemand::Install::Component['nginx_stage'],
       File['/opt/ood/nginx_stage/config/nginx_stage.yml'],
-      Exec['nginx_stage enable scl'],
-      File_line['ood_ruby-scl'],
+      File['/opt/ood/nginx_stage/bin/ood_ruby'],
     ],
   }
 

--- a/templates/apache/auth_openidc.conf.erb
+++ b/templates/apache/auth_openidc.conf.erb
@@ -8,3 +8,9 @@ OIDCCryptoPassphrase "<%= scope['openondemand::ood_auth_oidc_crypto_passphrase']
 # Keep sessions alive for 8 hours
 OIDCSessionInactivityTimeout 28800
 OIDCSessionMaxDuration 28800
+
+# Don't pass claims to backend servers
+OIDCPassClaimsAs environment
+
+# Strip out session cookies before passing to backend
+OIDCStripCookies mod_auth_openidc_session mod_auth_openidc_session_chunks mod_auth_openidc_session_0 mod_auth_openidc_session_1

--- a/templates/apache/ood-portal.conf.erb
+++ b/templates/apache/ood-portal.conf.erb
@@ -114,14 +114,23 @@ Listen <%= "#{scope['openondemand::ood_ip']}:#{scope['openondemand::ood_port']}"
   #    wss://<%= scope['openondemand::ood_server_name'] %><%= scope['openondemand::ood_node_uri'] %>/HOST/PORT/socket.io
   #    #=> ws://HOST:PORT<%= scope['openondemand::ood_node_uri'] %>/HOST/PORT/socket.io
   #
-  <LocationMatch "^<%= scope['openondemand::ood_node_uri'] %>/(?<host>[^/]+)/(?<port>[^/]+)">
+  <LocationMatch "^<%= scope['openondemand::ood_node_uri'] %>/(?<host><%= scope['openondemand::ood_host_regex'] %>)/(?<port>\d+)">
     AuthType "<%= scope['openondemand::ood_auth_type'] %>"
     Require valid-user
     <%- scope['openondemand::ood_auth_extend'].each do |ood_auth_extend| -%>
     <%= ood_auth_extend %>
     <%- end -%>
 
-    Header edit Location "^[^/]+//[^/:]+:[^/]+" ""
+    # ProxyPassReverse implementation
+    Header edit Location "^[^/]+//[^/]+" ""
+
+    # ProxyPassReverseCookieDomain implemenation
+    Header edit* Set-Cookie ";\s*(?i)Domain[^;]*" ""
+
+    # ProxyPassReverseCookiePath implementation
+    Header edit* Set-Cookie ";\s*(?i)Path[^;]*" ""
+    Header edit  Set-Cookie "^([^;]+)" "$1; Path=<%= scope['openondemand::ood_node_uri'] %>/%{MATCH_HOST}e/%{MATCH_PORT}e"
+
     LuaHookFixups node_proxy.lua node_proxy_handler
   </LocationMatch>
   <%- end -%>
@@ -135,14 +144,23 @@ Listen <%= "#{scope['openondemand::ood_ip']}:#{scope['openondemand::ood_port']}"
   #    wss://<%= scope['openondemand::ood_server_name'] %><%= scope['openondemand::ood_rnode_uri'] %>/HOST/PORT/socket.io
   #    #=> ws://HOST:PORT/socket.io
   #
-  <LocationMatch "^<%= scope['openondemand::ood_rnode_uri'] %>/(?<host>[^/]+)/(?<port>[^/]+)(?<uri>.*)">
+  <LocationMatch "^<%= scope['openondemand::ood_rnode_uri'] %>/(?<host><%= scope['openondemand::ood_host_regex'] %>)/(?<port>\d+)(?<uri>/.*|)">
     AuthType "<%= scope['openondemand::ood_auth_type'] %>"
     Require valid-user
     <%- scope['openondemand::ood_auth_extend'].each do |ood_auth_extend| -%>
     <%= ood_auth_extend %>
     <%- end -%>
 
-    Header edit Location "^[^/]+//[^/:]+:[^/]+" "/rnode/%{MATCH_HOST}e/%{MATCH_PORT}e"
+    # ProxyPassReverse implementation
+    Header edit Location "^([^/]+//[^/]+)|(?=/)" "<%= scope['openondemand::ood_rnode_uri'] %>/%{MATCH_HOST}e/%{MATCH_PORT}e"
+
+    # ProxyPassReverseCookieDomain implemenation
+    Header edit* Set-Cookie ";\s*(?i)Domain[^;]*" ""
+
+    # ProxyPassReverseCookiePath implementation
+    Header edit* Set-Cookie ";\s*(?i)Path[^;]*" ""
+    Header edit  Set-Cookie "^([^;]+)" "$1; Path=<%= scope['openondemand::ood_rnode_uri'] %>/%{MATCH_HOST}e/%{MATCH_PORT}e"
+
     LuaHookFixups node_proxy.lua node_proxy_handler
   </LocationMatch>
   <%- end -%>
@@ -168,6 +186,10 @@ Listen <%= "#{scope['openondemand::ood_ip']}:#{scope['openondemand::ood_port']}"
     SetEnv OOD_PUN_MAX_RETRIES "<%= scope['openondemand::ood_pun_max_retries'] %>"
     LuaHookFixups pun_proxy.lua pun_proxy_handler
     ProxyPassReverse "http://localhost<%= scope['openondemand::ood_pun_uri'] %>"
+    ProxyPassReverseCookieDomain "localhost" "<%= scope['openondemand::ood_server_name'] %>"
+
+    # ProxyPassReverseCookiePath implementation (less restrictive)
+    Header edit* Set-Cookie ";\s*(?i)Path\s*=(?-i)(?!\s*<%= scope['openondemand::ood_pun_uri'] %>)[^;]*" "; Path=<%= scope['openondemand::ood_pun_uri'] %>"
     <%- if scope['openondemand::ood_analytics_opt_in'] -%>
 
     SetEnv OOD_ANALYTICS_TRACKING_URL "<%= scope['openondemand::ood_analytics_tracking_url'] %>"

--- a/templates/nginx_stage.yml.erb
+++ b/templates/nginx_stage.yml.erb
@@ -18,12 +18,6 @@
 #
 #template_root: '/opt/ood/nginx_stage/templates'
 
-
-# Whether you agree to opt in to the collection of useful metrics for the
-# Open OnDemand project
-#
-opt_in_metrics: <%= scope['openondemand::nginx_stage_opt_in_metrics'] %>
-
 # The reverse proxy daemon user used to access the Unix domain sockets
 #
 #proxy_user: 'apache'

--- a/templates/ood_ruby.erb
+++ b/templates/ood_ruby.erb
@@ -1,0 +1,30 @@
+#!/bin/env bash
+
+# Open OnDemand Ruby wrapper script
+#
+# The purpose of this script is to wrap up the necessary environment for the
+# per-user NGINX (PUN) processes to run under. The PUN requires the following
+# software in its environment:
+#
+# - nginx 1.6
+# - passenger 4.0
+# - ruby 2.2
+# - node.js 0.10
+# - git 1.9
+#
+
+# For Software Collections 2.0
+#
+# 1. Read in environment variable SCL_PKGS which may be set in `sudo` call
+#    otherwise fallback to default software collection packages.
+#
+# 2. Check if Software Collections is installed, then source the defined
+#    package scripts.
+#
+SCL_PKGS=${SCL_PKGS:-"<%= scope['openondemand::nginx_stage_ood_ruby_scl'] %>"}
+SCL_SOURCE=$(command -v scl_source)
+[[ ${SCL_SOURCE} ]] && source ${SCL_SOURCE} enable ${SCL_PKGS}
+
+# Environment is set, so call Ruby now
+#
+exec /bin/env ruby "$@"


### PR DESCRIPTION
- I removed client-side analytics in favor of server-side analytics
- `mod_auth_openidc` v2.0.0+ has Apache directives that filter out sensitive information (**requires** latest `mod_auth_openidc` installed)
- I added security fixes as well as better support for proxying to backend web servers running on compute nodes
- updating `nginx_stage` on a server will not overwrite the `ood_ruby` wrapper script, so to ease updating the script in Puppet, I decided it would be simplest to just include it as a template much like you do with `nginx_stage.yml`

I was unable to run your tests, so you may want to check I didn't make any mistakes.