### PR TITLE
Fix double url encode query params

### DIFF
--- a/templates/apache/ood-portal.conf.erb
+++ b/templates/apache/ood-portal.conf.erb
@@ -1,7 +1,7 @@
 #
 # Open OnDemand Portal
 #
-# Generated using template v0.3.0
+# Generated using template v0.3.1
 #
 
 <% if @listen_addr_port -%>
@@ -22,7 +22,7 @@ Listen <%= addr_port %>
 #
 <VirtualHost *:80>
   RewriteEngine On
-  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @servername || "%{SERVER_NAME}" %>:<%= @port %>$1 [R=301,L]
+  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @servername || "%{SERVER_NAME}" %>:<%= @port %>$1 [R=301,NE,L]
 </VirtualHost>
 <% end -%>
 
@@ -37,7 +37,7 @@ Listen <%= addr_port %>
 
   RewriteEngine On
   RewriteCond %{HTTP_HOST} !^(<%= @servername %>(:<%= @port %>)?)?$ [NC]
-  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @servername %>:<%= @port %>$1 [R=301,L]
+  RewriteRule ^(.*) <%= @ssl ? "https" : "http" %>://<%= @servername %>:<%= @port %>$1 [R=301,NE,L]
   <%- end -%>
 
   <%- if @ssl -%>


### PR DESCRIPTION
Fixes https://github.com/OSC/ood-portal-generator/issues/9

Bugfixes:

  - fix double escaping query params on redirect