### PR TITLE
Fix that adds hidden cluster metadata

### DIFF
--- a/templates/cluster/main.yml.erb
+++ b/templates/cluster/main.yml.erb
@@ -73,6 +73,7 @@ v2:
   metadata:
     title: "<%= @cluster_title %>"
     url: "<%= @url %>"
+    hidden: <%= !@hpc_cluster %>
 <% if @group_validators && @group_validators["cluster"] -%>
   acls:
     - adapter: "group"


### PR DESCRIPTION
I forgot to add this metadata attribute used by the MyJobs app when it determines whether the cluster should be displayed or hidden from the user as a valid option for job submission.