### PR TITLE
Template used for generating OOD Portal updated

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class openondemand (
   String $lua_root = '/opt/ood/mod_ood_proxy/lib',
   Optional[String] $lua_log_level = undef,
   String $user_map_cmd  = '/opt/ood/ood_auth_map/bin/ood_auth_map.regex',
+  Optional[String] $user_env = undef,
   Optional[String] $map_fail_uri = undef,
   Enum['cilogon', 'openid-connect', 'shibboleth', 'ldap', 'basic'] $auth_type = 'basic',
   Optional[Array] $auth_configs = $openondemand::params::auth_configs,

--- a/templates/apache/ood-portal.conf.erb
+++ b/templates/apache/ood-portal.conf.erb
@@ -1,7 +1,7 @@
 #
 # Open OnDemand Portal
 #
-# Generated using template v0.3.1
+# Generated using template v0.4.0
 #
 
 <% if @listen_addr_port -%>
@@ -59,6 +59,9 @@ Listen <%= addr_port %>
   # Authenticated-user to system-user mapping configuration
   #
   SetEnv OOD_USER_MAP_CMD "<%= @user_map_cmd %>"
+  <%- if @user_env -%>
+  SetEnv OOD_USER_ENV "<%= @user_env %>"
+  <%- end -%>
   <%- if @map_fail_uri -%>
   SetEnv OOD_MAP_FAIL_URI "<%= @map_fail_uri %>"
   <%- end -%>


### PR DESCRIPTION
I updated the template included in [ood-portal-generator](https://github.com/OSC/ood-portal-generator). In particular I added an attribute called `user_env` defined as:

```yaml
# Use an alternative CGI environment variable instead of REMOTE_USER for
# determining the authenticated-user fed to the mapping script
# Example:
#     user_env: 'OIDC_CLAIM_preferred_username'
# Default: null (use REMOTE_USER)
#user_env: null
```

This came about due to Doug's request during an OOD meeting 3 months ago. Although `mod_auth_openidc` provides a very similar feature with `OIDCRemoteUserClaim`, it was brought up that OOD should be able to use any supplied CGI environment variable besides `REMOTE_USER` when mapping the authenticated user to a local user.

This can now be set in the Apache config with:

```apache
SetEnv OOD_USER_ENV "<env_var>"
```

This feature has since been included in [mod_ood_proxy v0.3.0](https://github.com/OSC/mod_ood_proxy/blob/master/CHANGELOG.md).